### PR TITLE
Add support for STORAGE_EMULATOR_HOST like the offical GCS go sdk.

### DIFF
--- a/gmutex/gmutex_test.go
+++ b/gmutex/gmutex_test.go
@@ -2,6 +2,7 @@ package gmutex_test
 
 import (
 	"context"
+	"crypto/tls"
 	"net/http"
 	"os"
 	"sync"
@@ -16,6 +17,9 @@ var object = os.Getenv("OBJECT")
 
 func TestMain(m *testing.M) {
 	gmutex.HTTPClient = http.DefaultClient
+	if os.Getenv("STORAGE_HOST_EMULATOR") != "" {
+		http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+	}
 	if bucket != "" && object != "" {
 		os.Exit(m.Run())
 	}


### PR DESCRIPTION
Closes https://github.com/ncruces/go-gcp/issues/4